### PR TITLE
rewrite search function done

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,6 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [clj-time "0.15.2"]]
+                 [clj-time "0.15.2"]
+                 [org.clojure/core.async "1.2.603"]]
   :repl-options {:init-ns clojure-training.core})

--- a/src/assignments/yunfeng/lesson_8_assignments.clj
+++ b/src/assignments/yunfeng/lesson_8_assignments.clj
@@ -1,0 +1,33 @@
+(ns assignments.yunfeng.lesson-8-assignments
+  (:require [clojure.core.async
+             :as a
+             :refer [>! <! >!! <!! go chan buffer close! thread
+                     alts! alts!! timeout]]))
+
+(def bing-url "https://www.bing.com/search?q=")
+(def yahoo-url "https://au.search.yahoo.com/search?p=")
+(def yippy-url "https://www.yippy.com/search?query=")
+
+
+(defn search
+  [search-string search-url c]
+  (let [result (slurp (str search-url search-string))]
+    (go (>! c result))))
+
+
+;;Compared with future and deliver approach, although only one result is printed it is possible to get all the other results(c1 c2 c3).
+(defn search-3
+  [search-string]
+  (let [c1 (chan) c2 (chan) c3 (chan)]
+    (search search-string bing-url c1)
+    (search search-string yahoo-url c2)
+    (search search-string yippy-url c3)
+    (let [[result channel] (alts!! [c1 c2 c3])]
+      (condp = channel
+        c1  (println "Bing is Winning." result)
+        c2  (println "Yahoo is Winning." result)
+        c3  (println "Yippy is Winning." result)))))
+
+(search-3 "ahkjsghjksgjk")
+
+


### PR DESCRIPTION
Both are using many threads to handle downloading the HTML file.  `go` is running the process on a thread pool while `future` creates a new thread. Moreover, `alts!` allows you to get the other results while with `future` and `deliver` approach, it is not possible.